### PR TITLE
Derivation work

### DIFF
--- a/hnix-store-aterm/hnix-store-aterm.cabal
+++ b/hnix-store-aterm/hnix-store-aterm.cabal
@@ -96,13 +96,9 @@ Test-Suite property
         hnix-store-core                      ,
         hnix-store-aterm                     ,
         hnix-store-tests                     ,
-        containers                           ,
         generic-arbitrary              < 1.1 ,
         QuickCheck                     < 2.16,
         text                                 ,
-        these                                ,
-        vector                         < 0.14,
-        filepath                       < 1.5
 
 Benchmark benchmark
     Import: commons

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -118,7 +118,6 @@ test-suite core
     tasty-discover:tasty-discover
   build-depends:
       hnix-store-core
-    , attoparsec
     , base
     , base16-bytestring
     , base64-bytestring
@@ -128,7 +127,6 @@ test-suite core
     , data-default-class
     , hspec
     , tasty
-    , tasty-golden
     , tasty-hspec
     , text
     , time

--- a/hnix-store-core/src/System/Nix/Derivation.hs
+++ b/hnix-store-core/src/System/Nix/Derivation.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- See TODOs bellow
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Shared types
 

--- a/hnix-store-readonly/hnix-store-readonly.cabal
+++ b/hnix-store-readonly/hnix-store-readonly.cabal
@@ -35,12 +35,9 @@ library
     , hnix-store-core >= 0.8
     , hnix-store-nar >= 0.1
     , bytestring
-    , constraints-extras
     , crypton
     , dependent-sum > 0.7
     , mtl
-    , text
-    , unordered-containers
   hs-source-dirs:      src
 
 test-suite readonly

--- a/hnix-store-readonly/tests/ReadOnlySpec.hs
+++ b/hnix-store-readonly/tests/ReadOnlySpec.hs
@@ -16,7 +16,7 @@ import System.Nix.ContentAddress (ContentAddressMethod(..))
 import Data.HashSet qualified
 import System.Nix.StorePath qualified
 
-import System.Nix.Store.ReadOnly
+import System.Nix.Store.ReadOnly ()
 
 testDigest :: DSum HashAlgo Digest
 testDigest = HashAlgo_SHA256 :=> Crypto.Hash.hash @ByteString "testDigest"

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -184,7 +184,6 @@ test-suite remote
     , bytestring
     , crypton
     , some > 1.0.5 && < 2
-    , time
     , hspec
     , QuickCheck
     , transformers

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
@@ -1395,7 +1395,7 @@ buildResult
   :: StoreDir
   -> ProtoVersion
   -> NixSerializer ReplySError BuildResult
-buildResult storeDir pv = Serializer
+buildResult _storeDir pv = Serializer
   { getS = do
       buildResultStatus <- mapGetER $ getS enum
       buildResultErrorMessage <- mapGetER $ getS maybeText

--- a/hnix-store-tests/hnix-store-tests.cabal
+++ b/hnix-store-tests/hnix-store-tests.cabal
@@ -68,10 +68,8 @@ library
     , generic-arbitrary < 1.1
     , hashable
     , hspec
-    , monoidal-containers
     , QuickCheck
     , text
-    , these
     , time
     , unordered-containers
     , vector
@@ -98,8 +96,6 @@ test-suite props
     , hnix-store-core
     , hnix-store-tests
     , attoparsec
-    , dependent-sum
-    , containers
     , text
     , hspec
     , QuickCheck


### PR DESCRIPTION
Some dedup needed but the `remote-io` testsuite passes.

Often `json` and `remote` testsuite seem to hang, `json` on 
```haskell
prop "Derivation" $ roundtripsJSON @Derivation
```
`remote` on the same thing but via serializer.

Also some funny serializer issue found by QC
```
  tests/NixSerializerSpec.hs:35:5:
  1) NixSerializer, Worker protocol, StoreRequest
       Falsifiable (after 28 tests and 2 shrinks):
         ProtoStoreConfig {protoStoreConfigDir = StoreDir {unStoreDir = "/\136mT\240pA"}, protoStoreConfigProtoVersion = ProtoVersion {protoVersion_major = 0, protoVersion_minor = 0}}
         Some (BuildDerivation StorePath /qcc11651aqrsgphcvlpdcr486q91b3v9-NTAe7OOS3LzZ+=q7MKjeejA7DxD-KYt9XO8RaeMGhK_w_w0gSrgB39AkH_NwqAU.Qt0VYGIX1P9pPwJ9HNila4agMpUSeoi_+vWG (Derivation {name = StorePathName {unStorePathName = "7r=z+AmfSuR?c9vQSzki"}, outputs = DerivationType_ContentAddressing :=> fromList [(OutputName {unOutputName = StorePathName {unStorePathName = "6vjD21k_BC0uL5gxv9R-q1gWU8K5gniUPeRj6TPsG"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "9yAZrHqJjl8JCA3PrRBVDk6=?bK.AE6ZoaTiaAs3xsLXU41"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA1}),(OutputName {unOutputName = StorePathName {unStorePathName = "B?aLyv-5wyqbZkRZRCwa?j5_cf+UmbfVN=UM+LQXr30QzF4dfBndxDh9.HA9ECJ05btlOFnOApyU2zqe-U0F7xoX4N7Q"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "I.nQRNFU?4iN=fWmFic8o_bCkeZoyN=i0.OEtZbjL._ypa5glhw+1zzmNzHoUc-PfHWypl?jCrknYtaSw6RdEzn?=gHAy47k1"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "IrALawSCQPOewBYU3p?YEx-VbiVDoqyr?+xQ.uG9tLytphVHQQzwRh-atqoD2LecARRw_WHPXmQADB_D8Sn1y?0GV59ylOz_YT"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "JQsgNPwtSbu_SRvIxrx404IDSCTh7rpRB3Mn5D.PVs2RifPYHqourE2VjkNN9eOuC7z_XcQqkYIDBNU?OgryXw_hNlYV-hjCX1mUieRY-8ILO0K4Q"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA1}),(OutputName {unOutputName = StorePathName {unStorePathName = "K8_TCi_3aWQ?=JzSoho08XhpcqKARUb3bFIj-YDjX3HBeuQDrhxzMI?k.MEsrq3k=j6r="}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA512}),(OutputName {unOutputName = StorePathName {unStorePathName = "OsG=emvUV00WeX?A.LJKlBxW78VcVqPW9r1p.Rm35x_hUpThyxIG-8nPIKEAH_LZPEaKrpveAbu+vBEY-pyiKwAZV1Wg9MozdOMqm7z5OS_PYiKC4AKbRXfAo"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "YN-YDcuc-Dw1jKk=b7Sq_C.wb5HnpBDhwte.cf33K790RprzG2BGSQf6MbZet3-LHfOoBHGC=p+vOgN=ftHBU4h-TlQWD7DRO-hMTBVcUun4CRQMdHMFaHSnAqh7pSltiRFzozFkL6hRquFpy"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "Zn.o01z5t9y-Ae38w1T9V"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "bYkQ5=l97SY9FFW_y3_1W"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "ihkFfGED-bZsM4JyZZd+TVJuEMWc.9AWFAPuP1VS6lga7FEt2BG"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "qAvYbQEEJtudO7oQOAeaD0enHERu8s-1utX4oCNTJutqqN7Jk?sKJC5piA?-6e6ugll9WdQd-hbBsERSjUE"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "xh=jSY5KNNZsuHdt5xNzH9O7AIQpuSIi6-vTEYZT53-oZ1U5Wg_RtC?lcnakAERmWk1W8Jsir"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "ztblXLqGvFr.oG05Td2_sXEV4OwbBgpB7_8cJg81GimX+69X3L7zs2U__"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA512})], inputs = fromList [StorePath /0000007h9711pgym9gvp0345isf20s5q-iY20YEl7gDY+.woyd9Fc3J4CxGNGz-oku_6b4W_R5TpmKjB6P+uIGplEf52l9=aYomSq?WkPF4IIA1e.=tITFJ33bz7xb91Xe_x4UnDgMQW-4XCOJtMSJaS+7aM5xzZMMgFhd6w36T6_HulBX-Pqhnj6D.ln4hU-5nb6lRxU_UeyC], platform = "8", builder = "", args = ["*","\50022v",""], env = fromList []}) BuildMode_Normal)
       expected: Right (Some (BuildDerivation StorePath /qcc11651aqrsgphcvlpdcr486q91b3v9-NTAe7OOS3LzZ+=q7MKjeejA7DxD-KYt9XO8RaeMGhK_w_w0gSrgB39AkH_NwqAU.Qt0VYGIX1P9pPwJ9HNila4agMpUSeoi_+vWG (Derivation {name = StorePathName {unStorePathName = "7r=z+AmfSuR?c9vQSzki"}, outputs = DerivationType_ContentAddressing :=> fromList [(OutputName {unOutputName = StorePathName {unStorePathName = "6vjD21k_BC0uL5gxv9R-q1gWU8K5gniUPeRj6TPsG"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "9yAZrHqJjl8JCA3PrRBVDk6=?bK.AE6ZoaTiaAs3xsLXU41"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA1}),(OutputName {unOutputName = StorePathName {unStorePathName = "B?aLyv-5wyqbZkRZRCwa?j5_cf+UmbfVN=UM+LQXr30QzF4dfBndxDh9.HA9ECJ05btlOFnOApyU2zqe-U0F7xoX4N7Q"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "I.nQRNFU?4iN=fWmFic8o_bCkeZoyN=i0.OEtZbjL._ypa5glhw+1zzmNzHoUc-PfHWypl?jCrknYtaSw6RdEzn?=gHAy47k1"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "IrALawSCQPOewBYU3p?YEx-VbiVDoqyr?+xQ.uG9tLytphVHQQzwRh-atqoD2LecARRw_WHPXmQADB_D8Sn1y?0GV59ylOz_YT"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "JQsgNPwtSbu_SRvIxrx404IDSCTh7rpRB3Mn5D.PVs2RifPYHqourE2VjkNN9eOuC7z_XcQqkYIDBNU?OgryXw_hNlYV-hjCX1mUieRY-8ILO0K4Q"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA1}),(OutputName {unOutputName = StorePathName {unStorePathName = "K8_TCi_3aWQ?=JzSoho08XhpcqKARUb3bFIj-YDjX3HBeuQDrhxzMI?k.MEsrq3k=j6r="}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA512}),(OutputName {unOutputName = StorePathName {unStorePathName = "OsG=emvUV00WeX?A.LJKlBxW78VcVqPW9r1p.Rm35x_hUpThyxIG-8nPIKEAH_LZPEaKrpveAbu+vBEY-pyiKwAZV1Wg9MozdOMqm7z5OS_PYiKC4AKbRXfAo"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "YN-YDcuc-Dw1jKk=b7Sq_C.wb5HnpBDhwte.cf33K790RprzG2BGSQf6MbZet3-LHfOoBHGC=p+vOgN=ftHBU4h-TlQWD7DRO-hMTBVcUun4CRQMdHMFaHSnAqh7pSltiRFzozFkL6hRquFpy"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "Zn.o01z5t9y-Ae38w1T9V"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "bYkQ5=l97SY9FFW_y3_1W"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "ihkFfGED-bZsM4JyZZd+TVJuEMWc.9AWFAPuP1VS6lga7FEt2BG"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "qAvYbQEEJtudO7oQOAeaD0enHERu8s-1utX4oCNTJutqqN7Jk?sKJC5piA?-6e6ugll9WdQd-hbBsERSjUE"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "xh=jSY5KNNZsuHdt5xNzH9O7AIQpuSIi6-vTEYZT53-oZ1U5Wg_RtC?lcnakAERmWk1W8Jsir"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "ztblXLqGvFr.oG05Td2_sXEV4OwbBgpB7_8cJg81GimX+69X3L7zs2U__"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA512})], inputs = fromList [StorePath /0000007h9711pgym9gvp0345isf20s5q-iY20YEl7gDY+.woyd9Fc3J4CxGNGz-oku_6b4W_R5TpmKjB6P+uIGplEf52l9=aYomSq?WkPF4IIA1e.=tITFJ33bz7xb91Xe_x4UnDgMQW-4XCOJtMSJaS+7aM5xzZMMgFhd6w36T6_HulBX-Pqhnj6D.ln4hU-5nb6lRxU_UeyC], platform = "8", builder = "", args = ["*","\50022v",""], env = fromList []}) BuildMode_Normal))
        but got: Right (Some (BuildDerivation StorePath /qcc11651aqrsgphcvlpdcr486q91b3v9-NTAe7OOS3LzZ+=q7MKjeejA7DxD-KYt9XO8RaeMGhK_w_w0gSrgB39AkH_NwqAU.Qt0VYGIX1P9pPwJ9HNila4agMpUSeoi_+vWG (Derivation {name = StorePathName {unStorePathName = "NTAe7OOS3LzZ+=q7MKjeejA7DxD-KYt9XO8RaeMGhK_w_w0gSrgB39AkH_NwqAU.Qt0VYGIX1P9pPwJ9HNila4agMpUSeoi_+vWG"}, outputs = DerivationType_ContentAddressing :=> fromList [(OutputName {unOutputName = StorePathName {unStorePathName = "6vjD21k_BC0uL5gxv9R-q1gWU8K5gniUPeRj6TPsG"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "9yAZrHqJjl8JCA3PrRBVDk6=?bK.AE6ZoaTiaAs3xsLXU41"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA1}),(OutputName {unOutputName = StorePathName {unStorePathName = "B?aLyv-5wyqbZkRZRCwa?j5_cf+UmbfVN=UM+LQXr30QzF4dfBndxDh9.HA9ECJ05btlOFnOApyU2zqe-U0F7xoX4N7Q"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "I.nQRNFU?4iN=fWmFic8o_bCkeZoyN=i0.OEtZbjL._ypa5glhw+1zzmNzHoUc-PfHWypl?jCrknYtaSw6RdEzn?=gHAy47k1"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "IrALawSCQPOewBYU3p?YEx-VbiVDoqyr?+xQ.uG9tLytphVHQQzwRh-atqoD2LecARRw_WHPXmQADB_D8Sn1y?0GV59ylOz_YT"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "JQsgNPwtSbu_SRvIxrx404IDSCTh7rpRB3Mn5D.PVs2RifPYHqourE2VjkNN9eOuC7z_XcQqkYIDBNU?OgryXw_hNlYV-hjCX1mUieRY-8ILO0K4Q"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA1}),(OutputName {unOutputName = StorePathName {unStorePathName = "K8_TCi_3aWQ?=JzSoho08XhpcqKARUb3bFIj-YDjX3HBeuQDrhxzMI?k.MEsrq3k=j6r="}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA512}),(OutputName {unOutputName = StorePathName {unStorePathName = "OsG=emvUV00WeX?A.LJKlBxW78VcVqPW9r1p.Rm35x_hUpThyxIG-8nPIKEAH_LZPEaKrpveAbu+vBEY-pyiKwAZV1Wg9MozdOMqm7z5OS_PYiKC4AKbRXfAo"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Text, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "YN-YDcuc-Dw1jKk=b7Sq_C.wb5HnpBDhwte.cf33K790RprzG2BGSQf6MbZet3-LHfOoBHGC=p+vOgN=ftHBU4h-TlQWD7DRO-hMTBVcUun4CRQMdHMFaHSnAqh7pSltiRFzozFkL6hRquFpy"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "Zn.o01z5t9y-Ae38w1T9V"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "bYkQ5=l97SY9FFW_y3_1W"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "ihkFfGED-bZsM4JyZZd+TVJuEMWc.9AWFAPuP1VS6lga7FEt2BG"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_Flat, caHashAlgo = Some HashAlgo_SHA256}),(OutputName {unOutputName = StorePathName {unStorePathName = "qAvYbQEEJtudO7oQOAeaD0enHERu8s-1utX4oCNTJutqqN7Jk?sKJC5piA?-6e6ugll9WdQd-hbBsERSjUE"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "xh=jSY5KNNZsuHdt5xNzH9O7AIQpuSIi6-vTEYZT53-oZ1U5Wg_RtC?lcnakAERmWk1W8Jsir"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_MD5}),(OutputName {unOutputName = StorePathName {unStorePathName = "ztblXLqGvFr.oG05Td2_sXEV4OwbBgpB7_8cJg81GimX+69X3L7zs2U__"}},ContentAddressedDerivationOutput {caMethod = ContentAddressMethod_NixArchive, caHashAlgo = Some HashAlgo_SHA512})], inputs = fromList [StorePath /0000007h9711pgym9gvp0345isf20s5q-iY20YEl7gDY+.woyd9Fc3J4CxGNGz-oku_6b4W_R5TpmKjB6P+uIGplEf52l9=aYomSq?WkPF4IIA1e.=tITFJ33bz7xb91Xe_x4UnDgMQW-4XCOJtMSJaS+7aM5xzZMMgFhd6w36T6_HulBX-Pqhnj6D.ln4hU-5nb6lRxU_UeyC], platform = "8", builder = "", args = ["*","\50022v",""], env = fromList []}) BuildMode_Normal))

  To rerun use: --match "/NixSerializer/Worker protocol/StoreRequest/" --seed 1461166811

Randomized with seed 1461166811
```

This seems to be caused by `with/withoutName` and a mismatch between store path and derivation name.