### PR TITLE
Arbitrary BuildDerivation matching storePathName and drv name

### DIFF
--- a/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
@@ -5,6 +5,8 @@ module System.Nix.Store.Remote.Arbitrary where
 
 import Data.Some (Some(Some))
 import System.Nix.Arbitrary ()
+import System.Nix.Derivation (Derivation'(name))
+import System.Nix.StorePath
 import System.Nix.Store.Types (RepairMode(..))
 import System.Nix.Store.Remote.Types
 
@@ -101,7 +103,8 @@ instance Arbitrary (Some StoreRequest) where
     , Some . AddIndirectRoot  <$> arbitrary
     , Some . AddTempRoot <$> arbitrary
     , Some <$> (BuildPaths <$> arbitrary <*> arbitrary)
-    , Some <$> (BuildDerivation <$> arbitrary <*> arbitrary <*> arbitrary)
+    -- derivation name matches storePathName of the first StorePath argument
+    , Some <$> ((\(BuildDerivation a b c) -> BuildDerivation a (b { name = storePathName a}) c) <$> (BuildDerivation <$> arbitrary <*> arbitrary <*> arbitrary))
     , Some . CollectGarbage <$> arbitrary
     , Some . EnsurePath <$> arbitrary
     , pure $ Some FindRoots


### PR DESCRIPTION
Not exactly pretty as something feels redundant but fixes the last problem with the testsuite. 